### PR TITLE
Proposed comment and naming changes

### DIFF
--- a/contracts/DecentralistProxyFactory.sol
+++ b/contracts/DecentralistProxyFactory.sol
@@ -17,8 +17,8 @@ contract DecentralistProxyFactory {
     event NewClone(address _clone);
 
     /**
-    * @param _implementation is the address decentraList address that clones will be based on.
-    * @param _finder is the address of UMA address finder. This is set in the DecentralistProxyFactory constructor.
+    * @param _implementation The decentraList implementation contract that clones will be based on.
+    * @param _finder The address of UMA Finder contract. This is set in the DecentralistProxyFactory constructor.
     */
     constructor(address _implementation, address _finder) {
         require(_finder != address(0), "implementation address can not be empty");
@@ -29,15 +29,15 @@ contract DecentralistProxyFactory {
     }
 
     /**
-    * @notice creates new decentraList smart contract
-    * @param _listCriteria Criteria for what addresses should be included on list. Can be text or link to IPFS.
-    * @param _title Short title for the list
-    * @param _token is the address of the token currency used for this contract. Must be on UMA's collateral whitelist
-    * @param _bondAmount Additional bond required, beyond the final fee
-    * @param _addReward Reward per address successfully added to the list, paid by contract to proposer
-    * @param _removeReward Reward per address successfully removed from the list, paid by contract to proposer
-    * @param _liveness The period, in seconds, in which a proposal can be disputed. Must be greater than 8 hours
-    * @param _owner Owner of contract can remove funds from contract and adjust reward rates. Set to 0 address to make contract 'public'.
+    * @notice Creates a new decentraList smart contract.
+    * @param _listCriteria Criteria for what addresses should be included on the list. Can be on-chain text or a link to IPFS.
+    * @param _title Short title for the list.
+    * @param _token The address of the token currency used for this contract. Must be on UMA's collateral whitelist.
+    * @param _bondAmount Additional bond required, beyond the final fee.
+    * @param _addReward Reward per address successfully added to the list, paid by the contract to the proposer.
+    * @param _removeReward Reward per address successfully removed from the list, paid by the contract to the proposer.
+    * @param _liveness The period, in seconds, in which a proposal can be disputed. Must be greater than 8 hours.
+    * @param _owner Owner of the contract can remove funds from the contract and adjust reward rates. Set to the 0 address to make the contract 'public'.
     */
     function createNewDecentralist(
         bytes memory _listCriteria,
@@ -69,7 +69,7 @@ contract DecentralistProxyFactory {
                 _owner
             )
         );
-        require(success, "instance.call failed");
+        require(success, "failed to create a new instance");
 
         // store new address
         allClones.push(instance);
@@ -78,16 +78,16 @@ contract DecentralistProxyFactory {
     }
 
     /**
-    * @notice returns all addresses created
+    * @notice Returns all instances created.
     */
 	function getAllClones() public view returns(address[] memory) {
 		return allClones;
 	}
 
     /**
-     * @notice This pulls in the most up-to-date Collateral Whitelist.
-     * @dev If a new OptimisticOracle is added and this is run between a revision's introduction and execution, the
-     * proposal will become unexecutable.
+     * @notice This pulls in the most up-to-date collateral whitelist.
+     * @dev If a new OptimisticOracle is added and this function is run between a list revision's proposal and execution,
+     * the proposal will become unexecutable.
      */
     function syncWhitelist() public {
         collateralWhitelist = AddressWhitelistInterface(finder.getImplementationAddress(OracleInterfaces.CollateralWhitelist));

--- a/contracts/decentralist.sol
+++ b/contracts/decentralist.sol
@@ -21,7 +21,7 @@ contract Decentralist is Initializable, Ownable {
     event RevisionRejected(uint256 indexed revisionId, int256 proposedValue);
     event RevisionExecuted(uint256 indexed revisionId, int256 proposedValue, address[] revisedAddresses);
 
-    event RewardsSet(uint256 addReward, uint256 removeReward);
+    event RewardsSet(uint256 additionReward, uint256 removalReward);
     event LivenessSet(uint64 liveness);
     event BondSet(uint256 bondAmount);
     
@@ -32,8 +32,8 @@ contract Decentralist is Initializable, Ownable {
     string public title;
     uint256 public bondAmount;
     IERC20 public token;
-    uint256 public addReward;
-    uint256 public removeReward;
+    uint256 public additionReward;
+    uint256 public removalReward;
     uint64 public liveness;
     uint256 private revisionCounter;
 
@@ -63,16 +63,16 @@ contract Decentralist is Initializable, Ownable {
     mapping(address => bool) public onList;
 
     /**
-     * @notice Initialize contract
-     * @param _finder is the address of UMA address finder. This is set in the DecentralistProxyFactory constructor.
-     * @param _listCriteria Criteria for what addresses should be included on list. Can be text or link to IPFS.
-     * @param _title Short title for the list
-     * @param _token is the address of the token currency used for this contract. Must be on UMA's collateral whitelist
-     * @param _bondAmount Additional bond required, beyond the final fee
-     * @param _addReward Reward per address successfully added to the list, paid by contract to proposer
-     * @param _removeReward Reward per address successfully removed from the list, paid by contract to proposer
-     * @param _liveness The period, in seconds, in which a proposal can be disputed. Must be greater than 8 hours
-     * @param _owner Owner of contract can remove funds from contract and adjust reward rates. Set to 0 address to make contract 'public'.
+     * @notice Initializes the contract.
+     * @param _finder The address of UMA Finder contract. This is set in the DecentralistProxyFactory constructor.
+     * @param _listCriteria Criteria for what addresses should be included on the list. Can be on-chain text or a link to IPFS.
+     * @param _title Short title for the list.
+     * @param _token The address of the token currency used for this contract. Must be on UMA's collateral whitelist.
+     * @param _bondAmount Additional bond required, beyond the final fee.
+     * @param _additionReward Reward per address successfully added to the list, paid by the contract to the proposer.
+     * @param _removalReward Reward per address successfully removed from the list, paid by the contract to the proposer.
+     * @param _liveness The period, in seconds, in which a proposal can be disputed. Must be greater than 8 hours.
+     * @param _owner Owner of the contract can remove funds from the contract and adjust reward rates. Set to the 0 address to make the contract 'public'.
      */
     function initialize(
         address _finder,
@@ -80,8 +80,8 @@ contract Decentralist is Initializable, Ownable {
         string memory _title,
         address _token,
         uint256 _bondAmount,
-        uint256 _addReward,
-        uint256 _removeReward,
+        uint256 _additionReward,
+        uint256 _removalReward,
         uint64 _liveness,
         address _owner
     ) public initializer {
@@ -94,8 +94,8 @@ contract Decentralist is Initializable, Ownable {
         title = _title;
         token = IERC20(_token);
         bondAmount = _bondAmount;
-        addReward = _addReward;
-        removeReward = _removeReward;
+        additionReward = _additionReward;
+        removalReward = _removalReward;
         liveness = _liveness;
 
         _transferOwnership(_owner);
@@ -105,10 +105,10 @@ contract Decentralist is Initializable, Ownable {
     }
 
     /**
-     * @notice Proposes addresses to add or remove from the list
-     * @param _value for the proposed revision. 0 = remove, 1e18 = add
-     * @param _addresses array of addresses for the proposed revision
-     * @dev Caller must have approved this contract to spend the total bond amount of the contract's token before calling
+     * @notice Proposes addresses to add or remove from the list.
+     * @param _value Indicates if the proposed revision is adding or removing addresses. 0 = remove, 1e18 = add.
+     * @param _addresses Array of addresses for the proposed revision.
+     * @dev Caller must have approved this contract to spend the total bond amount of the contract's token before calling.
      */
     function proposeRevision(int256 _value, address[] calldata _addresses)
         public
@@ -197,10 +197,10 @@ contract Decentralist is Initializable, Ownable {
     }
 
     /**
-     * @notice Callback function called upon oracle data settlement to update the Revision status to Approved or Rejected
-     * @param timestamp timestamp to identify the existing request.
-     * @param ancillaryData ancillary data of the data being requested.
-     * @param value value returned from the oracle
+     * @notice Callback function called upon oracle data settlement to update the Revision status to Approved or Rejected.
+     * @param timestamp Timestamp to identify the existing request.
+     * @param ancillaryData Ancillary data of the data being requested.
+     * @param value Value returned from the oracle.
      */
     function priceSettled(
         bytes32, /* identifier */
@@ -232,9 +232,9 @@ contract Decentralist is Initializable, Ownable {
     }
 
     /**
-     * @notice executes approved revisions by revising list and paying out rewards to proposer
-     * @param _revisionId to be executed. If Revision submitted does not have status Approved, tx will revert.
-     * @param _addresses address array that matches the array logged in the RevisionProposed event for the provided _revisionId
+     * @notice Executes approved revisions by revising the list and paying out rewards to the proposer.
+     * @param _revisionId ID of revision to be executed. If Revision submitted does not have status Approved, tx will revert.
+     * @param _addresses Address array that matches the array logged in the RevisionProposed event for the provided _revisionId.
      */
     function executeRevision(uint256 _revisionId, address[] calldata _addresses)
         external
@@ -254,11 +254,11 @@ contract Decentralist is Initializable, Ownable {
 
         // default newListValue and rewardRate to remove addresses
         bool newListValue = false;
-        uint256 rewardRate = removeReward;
+        uint256 rewardRate = removalReward;
         // if Revision proposedValue is to add addresses, set newListValue and rewardRate to add addresses
         if (revisions[_revisionId].proposedValue == PROPOSAL_YES_RESPONSE) {
             newListValue = true;
-            rewardRate = addReward;
+            rewardRate = additionReward;
         }
 
         // add or remove address from the list, increment rewardCounter for calculating rewards and record revised Addresses
@@ -289,35 +289,42 @@ contract Decentralist is Initializable, Ownable {
     }
 
     /**
-     * @notice Allows owner to withdraw funds from the contract.
-     * @param recipient of funds
-     * @param amount to send
+     * @notice Allows owner to withdraw the default bond tokens from the contract.
+     * @param recipient The recipient of the tokens.
+     * @param amount The amount of tokens to to send.
      */
     function withdraw(address recipient, uint256 amount) external onlyOwner {
         token.transfer(recipient, amount);
     }
 
     /**
-     * @notice Sets the add and remove rewards for successful revisions
-     * @param _addReward reward to proposer per address successfully added to the list
-     * @param _removeReward reward to proposer per address successfully removed from the list
+     * @notice Allows owner to rescue tokens sent accidentally to the contract.
+     * @param recipient The recipient of the tokens.
+     * @param amount The amount of tokens to to send.
+     * @param _token The contract address of the token to send.
      */
-    function setRewards(uint256 _addReward, uint256 _removeReward) public onlyOwner {
-        addReward = _addReward;
-        removeReward = _removeReward;
-        emit RewardsSet(_addReward, _removeReward);
+    function rescue(address recipient, uint256 amount, address _token) external onlyOwner {
+        IERC20(_token).transfer(recipient, amount);
+    }
+
+    /**
+     * @notice Sets the rewards for successful revisions.
+     * @param _additionReward Reward to proposer per address successfully added to the list.
+     * @param _removalReward Reward to proposer per address successfully removed from the list.
+     */
+    function setRewards(uint256 _additionReward, uint256 _removalReward) public onlyOwner {
+        additionReward = _additionReward;
+        removalReward = _removalReward;
+        emit RewardsSet(_additionReward, _removalReward);
     }
 
     /**
      * @notice Sets the bond amount for revisions.
-     * @param _bondAmount amount of the bond token that will need to be paid for future proposals.
+     * @param _bondAmount Amount of the bond token that will need to be paid for future proposals.
      */
     function setBond(uint256 _bondAmount) public onlyOwner {
         // Value of the bond required for proposing revisions, in addition to the final fee. A bond of zero is
         // acceptable, in which case the Optimistic Oracle will require the final fee as the bond.
-
-        //TO DO: after testing add require(bondAmount >= final fee)
-        
         bondAmount = _bondAmount;
         emit BondSet(_bondAmount);
     }
@@ -325,7 +332,7 @@ contract Decentralist is Initializable, Ownable {
     /**
      * @notice Sets the liveness for future revisions. This is the amount of delay before a proposal is approved by
      * default.
-     * @param _liveness liveness to set in seconds.
+     * @param _liveness Liveness to set in seconds.
      */
     function setLiveness(uint64 _liveness) public onlyOwner {
         // TO DO: remove comments after testing
@@ -336,7 +343,7 @@ contract Decentralist is Initializable, Ownable {
     }
 
     /**
-     * @notice This pulls in the most up-to-date Optimistic Oracle.
+     * @notice This pulls in the most up-to-date Optimistic Oracle contract.
      * @dev If a new OptimisticOracle is added and this is run between a revision's introduction and execution, the
      * proposal will become unexecutable.
      */


### PR DESCRIPTION
This PR improves some of the comments and renames some functions, variables, etc. for clarity.

* `price` is changed to `value` or `data` in various locations. The `requestPrice1, `proposePriceFor`, and `priceSettled` functions are unchanged since those are still the function names in the oracle interface, a legacy of the oracles previous focus on synthetic assets and price data.
* `PRICE_ID` is changed to `IDENTIFIER`
* `addReward` and `removeReward` are changed to `additionReward` and `removalReward` respectively
* adds a `rescue` function for tokens besides the bond token that were sent to the contract accidentally
* various other changes

Some of these changes may require changes in the front-end code to match the new names, but the functionality has not been meaningfully changed. Please push back on any of these changes you don't think make sense, as well.